### PR TITLE
Added code for using FSDKaggle2018 Dataset for Audition tasks

### DIFF
--- a/benchmarks/audition/fsdd.py
+++ b/benchmarks/audition/fsdd.py
@@ -267,13 +267,15 @@ if __name__ == "__main__":
     parser.add_argument("-labels", help="labels file location")
     args = parser.parse_args()
     n_classes = int(args.m)
-    feature_type = str(args.f)    
-    
+    feature_type = str(args.f)
+
     train_folder = str(args.data)
     train_label = pd.read_csv(str(args.labels))
-    
+
     # select subset of data that only contains 300 samples per class
-    labels_chosen = train_label[train_label['label'].map(train_label['label'].value_counts() == 300)]
+    labels_chosen = train_label[
+        train_label["label"].map(train_label["label"].value_counts() == 300)
+    ]
 
     training_files = []
     for file in os.listdir(train_folder):
@@ -283,18 +285,39 @@ if __name__ == "__main__":
 
     path_recordings = []
     for audiofile in training_files:
-        path_recordings.append(os.path.join(train_folder,audiofile))
+        path_recordings.append(os.path.join(train_folder, audiofile))
 
     # convert selected label names to integers
-    labels_to_index = {'Acoustic_guitar': 0, 'Applause': 1, 'Bass_drum': 2, 'Trumpet': 3,'Clarinet': 4,'Double_bass': 5,'Laughter': 6,'Shatter': 7, 'Snare_drum': 8,'Saxophone': 9,'Tearing': 10,'Flute': 11,'Hi-hat': 12,'Violin_or_fiddle': 13,'Squeak': 14,'Fart': 15,'Fireworks': 16,'Cello': 17}
+    labels_to_index = {
+        "Acoustic_guitar": 0,
+        "Applause": 1,
+        "Bass_drum": 2,
+        "Trumpet": 3,
+        "Clarinet": 4,
+        "Double_bass": 5,
+        "Laughter": 6,
+        "Shatter": 7,
+        "Snare_drum": 8,
+        "Saxophone": 9,
+        "Tearing": 10,
+        "Flute": 11,
+        "Hi-hat": 12,
+        "Violin_or_fiddle": 13,
+        "Squeak": 14,
+        "Fart": 15,
+        "Fireworks": 16,
+        "Cello": 17,
+    }
 
     # encode labels to integers
-    get_labels = labels_chosen['label'].replace(labels_to_index).to_list()
+    get_labels = labels_chosen["label"].replace(labels_to_index).to_list()
     labels_chosen = labels_chosen.reset_index()
-    
+
     # data is normalized upon loading
     # load dataset
-    x_spec, y_number = load_spoken_digit(path_recordings,labels_chosen,get_labels,feature_type)
+    x_spec, y_number = load_spoken_digit(
+        path_recordings, labels_chosen, get_labels, feature_type
+    )
     nums = list(range(18))
     samples_space = np.geomspace(10, 450, num=6, dtype=int)
     # define path, samples space and number of class combinations
@@ -314,7 +337,14 @@ if __name__ == "__main__":
     y_number = np.array(y_number)
 
     # need to take train/valid/test equally from each class
-    trainx, testx, trainy, testy = train_test_split(x_spec,y_number,shuffle=True,test_size=0.25, train_size=0.50, stratify=y_number)
+    trainx, testx, trainy, testy = train_test_split(
+        x_spec,
+        y_number,
+        shuffle=True,
+        test_size=0.25,
+        train_size=0.50,
+        stratify=y_number,
+    )
 
     # 3000 samples, 80% train is 2400 samples, 20% test
     fsdd_train_images = trainx.reshape(-1, 32 * 32)

--- a/benchmarks/audition/fsdd.py
+++ b/benchmarks/audition/fsdd.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
         x_spec,
         y_number,
         shuffle=True,
-        test_size=0.25,
+        test_size=0.50,
         train_size=0.50,
         stratify=y_number,
     )

--- a/benchmarks/audition/fsdd.py
+++ b/benchmarks/audition/fsdd.py
@@ -1,0 +1,326 @@
+"""
+Coauthors: Haoyin Xu
+           Yu-Chung Peng
+           Madi Kusmanov
+"""
+from toolbox import *
+import argparse
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.preprocessing import scale
+
+import torchvision.models as models
+import warnings
+import random
+
+warnings.filterwarnings("ignore")
+
+
+def run_naive_rf():
+    naive_rf_kappa = []
+    naive_rf_ece = []
+    naive_rf_train_time = []
+    naive_rf_test_time = []
+    for classes in classes_space:
+
+        # cohen_kappa vs num training samples (naive_rf)
+        for samples in samples_space:
+            # train data
+            RF = RandomForestClassifier(n_estimators=100, n_jobs=-1)
+            cohen_kappa, ece, train_time, test_time = run_rf_image_set(
+                RF,
+                fsdd_train_images,
+                fsdd_train_labels,
+                fsdd_test_images,
+                fsdd_test_labels,
+                samples,
+                classes,
+            )
+            naive_rf_kappa.append(cohen_kappa)
+            naive_rf_ece.append(ece)
+            naive_rf_train_time.append(train_time)
+            naive_rf_test_time.append(test_time)
+
+    print("naive_rf finished")
+    write_result(prefix + "naive_rf_kappa.txt", naive_rf_kappa)
+    write_result(prefix + "naive_rf_ece.txt", naive_rf_ece)
+    write_result(prefix + "naive_rf_train_time.txt", naive_rf_train_time)
+    write_result(prefix + "naive_rf_test_time.txt", naive_rf_test_time)
+
+
+def run_cnn32():
+    cnn32_kappa = []
+    cnn32_ece = []
+    cnn32_train_time = []
+    cnn32_test_time = []
+    for classes in classes_space:
+
+        # cohen_kappa vs num training samples (cnn32)
+        for samples in samples_space:
+            # train data
+            cnn32 = SimpleCNN32Filter(len(classes))
+            # 3000 samples, 80% train is 2400 samples, 20% test
+            train_images = trainx.copy()
+            train_labels = trainy.copy()
+            # reshape in 4d array
+            test_images = testx.copy()
+            test_labels = testy.copy()
+
+            (
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            ) = prepare_data(
+                train_images, train_labels, test_images, test_labels, samples, classes
+            )
+
+            cohen_kappa, ece, train_time, test_time = run_dn_image_es(
+                cnn32,
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            )
+            cnn32_kappa.append(cohen_kappa)
+            cnn32_ece.append(ece)
+            cnn32_train_time.append(train_time)
+            cnn32_test_time.append(test_time)
+
+    print("cnn32 finished")
+    write_result(prefix + "cnn32_kappa.txt", cnn32_kappa)
+    write_result(prefix + "cnn32_ece.txt", cnn32_ece)
+    write_result(prefix + "cnn32_train_time.txt", cnn32_train_time)
+    write_result(prefix + "cnn32_test_time.txt", cnn32_test_time)
+
+
+def run_cnn32_2l():
+    cnn32_2l_kappa = []
+    cnn32_2l_ece = []
+    cnn32_2l_train_time = []
+    cnn32_2l_test_time = []
+    for classes in classes_space:
+
+        # cohen_kappa vs num training samples (cnn32_2l)
+        for samples in samples_space:
+            # train data
+            cnn32_2l = SimpleCNN32Filter2Layers(len(classes))
+            # 3000 samples, 80% train is 2400 samples, 20% test
+            train_images = trainx.copy()
+            train_labels = trainy.copy()
+            # reshape in 4d array
+            test_images = testx.copy()
+            test_labels = testy.copy()
+
+            (
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            ) = prepare_data(
+                train_images, train_labels, test_images, test_labels, samples, classes
+            )
+
+            cohen_kappa, ece, train_time, test_time = run_dn_image_es(
+                cnn32_2l,
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            )
+            cnn32_2l_kappa.append(cohen_kappa)
+            cnn32_2l_ece.append(ece)
+            cnn32_2l_train_time.append(train_time)
+            cnn32_2l_test_time.append(test_time)
+
+    print("cnn32_2l finished")
+    write_result(prefix + "cnn32_2l_kappa.txt", cnn32_2l_kappa)
+    write_result(prefix + "cnn32_2l_ece.txt", cnn32_2l_ece)
+    write_result(prefix + "cnn32_2l_train_time.txt", cnn32_2l_train_time)
+    write_result(prefix + "cnn32_2l_test_time.txt", cnn32_2l_test_time)
+
+
+def run_cnn32_5l():
+    cnn32_5l_kappa = []
+    cnn32_5l_ece = []
+    cnn32_5l_train_time = []
+    cnn32_5l_test_time = []
+    for classes in classes_space:
+
+        # cohen_kappa vs num training samples (cnn32_5l)
+        for samples in samples_space:
+            # train data
+            cnn32_5l = SimpleCNN32Filter5Layers(len(classes))
+            # 3000 samples, 80% train is 2400 samples, 20% test
+            train_images = trainx.copy()
+            train_labels = trainy.copy()
+            # reshape in 4d array
+            test_images = testx.copy()
+            test_labels = testy.copy()
+
+            (
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            ) = prepare_data(
+                train_images, train_labels, test_images, test_labels, samples, classes
+            )
+
+            cohen_kappa, ece, train_time, test_time = run_dn_image_es(
+                cnn32_5l,
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            )
+            cnn32_5l_kappa.append(cohen_kappa)
+            cnn32_5l_ece.append(ece)
+            cnn32_5l_train_time.append(train_time)
+            cnn32_5l_test_time.append(test_time)
+
+    print("cnn32_5l finished")
+    write_result(prefix + "cnn32_5l_kappa.txt", cnn32_5l_kappa)
+    write_result(prefix + "cnn32_5l_ece.txt", cnn32_5l_ece)
+    write_result(prefix + "cnn32_5l_train_time.txt", cnn32_5l_train_time)
+    write_result(prefix + "cnn32_5l_test_time.txt", cnn32_5l_test_time)
+
+
+def run_resnet18():
+    resnet18_kappa = []
+    resnet18_ece = []
+    resnet18_train_time = []
+    resnet18_test_time = []
+    for classes in classes_space:
+
+        # cohen_kappa vs num training samples (resnet18)
+        for samples in samples_space:
+            resnet = models.resnet18(pretrained=True)
+
+            num_ftrs = resnet.fc.in_features
+            resnet.fc = nn.Linear(num_ftrs, len(classes))
+            # train data
+            # 3000 samples, 80% train is 2400 samples, 20% test
+            train_images = trainx.copy()
+            train_labels = trainy.copy()
+            # reshape in 4d array
+            test_images = testx.copy()
+            test_labels = testy.copy()
+
+            (
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            ) = prepare_data(
+                train_images, train_labels, test_images, test_labels, samples, classes
+            )
+
+            # need to duplicate channel because batch norm cant have 1 channel images
+            train_images = torch.cat((train_images, train_images, train_images), dim=1)
+            valid_images = torch.cat((valid_images, valid_images, valid_images), dim=1)
+            test_images = torch.cat((test_images, test_images, test_images), dim=1)
+
+            cohen_kappa, ece, train_time, test_time = run_dn_image_es(
+                resnet,
+                train_images,
+                train_labels,
+                valid_images,
+                valid_labels,
+                test_images,
+                test_labels,
+            )
+            resnet18_kappa.append(cohen_kappa)
+            resnet18_ece.append(ece)
+            resnet18_train_time.append(train_time)
+            resnet18_test_time.append(test_time)
+
+    print("resnet18 finished")
+    write_result(prefix + "resnet18_kappa.txt", resnet18_kappa)
+    write_result(prefix + "resnet18_ece.txt", resnet18_ece)
+    write_result(prefix + "resnet18_train_time.txt", resnet18_train_time)
+    write_result(prefix + "resnet18_test_time.txt", resnet18_test_time)
+
+
+if __name__ == "__main__":
+    torch.multiprocessing.freeze_support()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", help="class number")
+    parser.add_argument("-f", help="feature type")
+    args = parser.parse_args()
+    n_classes = int(args.m)
+    feature_type = str(args.f)
+    path_recordings = "recordings/"
+
+    # data is normalized upon loading
+    # load dataset
+    x_spec, y_number = load_spoken_digit(path_recordings, feature_type)
+    nums = list(range(10))
+    samples_space = np.geomspace(10, 480, num=6, dtype=int)
+    # define path, samples space and number of class combinations
+    if feature_type == "melspectrogram":
+        prefix = args.m + "_class_mel/"
+    elif feature_type == "spectrogram":
+        prefix = args.m + "_class/"
+    elif feature_type == "mfcc":
+        prefix = args.m + "_class_mfcc/"
+
+    # create list of classes with const random seed
+    random.Random(5).shuffle(nums)
+    classes_space = list(combinations_45(nums, n_classes))
+
+    # scale the data
+    x_spec = scale(x_spec.reshape(3000, -1), axis=1).reshape(3000, 32, 32)
+    y_number = np.array(y_number)
+
+    # need to take train/valid/test equally from each class
+    trainx = np.zeros((1, 32, 32))
+    trainy = np.zeros((1))
+    testx = np.zeros((1, 32, 32))
+    testy = np.zeros((1))
+    for i in range(10):
+        shuffler = np.random.permutation(300)
+        trainx = np.concatenate(
+            (trainx, x_spec[i * 300 : (i + 1) * 3000][shuffler][:240])
+        )
+        trainy = np.concatenate(
+            (trainy, y_number[i * 300 : (i + 1) * 3000][shuffler][:240])
+        )
+        testx = np.concatenate(
+            (testx, x_spec[i * 300 : (i + 1) * 3000][shuffler][240:])
+        )
+        testy = np.concatenate(
+            (testy, y_number[i * 300 : (i + 1) * 3000][shuffler][240:])
+        )
+    trainx = trainx[1:]
+    trainy = trainy[1:]
+    testx = testx[1:]
+    testy = testy[1:]
+
+    # 3000 samples, 80% train is 2400 samples, 20% test
+    fsdd_train_images = trainx.reshape(-1, 32 * 32)
+    fsdd_train_labels = trainy.copy()
+    # reshape in 2d array
+    fsdd_test_images = testx.reshape(-1, 32 * 32)
+    fsdd_test_labels = testy.copy()
+
+    run_naive_rf()
+    run_cnn32()
+    run_cnn32_2l()
+    run_cnn32_5l()
+    run_resnet18()

--- a/benchmarks/audition/fsdk18.py
+++ b/benchmarks/audition/fsdk18.py
@@ -30,10 +30,10 @@ def run_naive_rf():
             RF = RandomForestClassifier(n_estimators=100, n_jobs=-1)
             cohen_kappa, ece, train_time, test_time = run_rf_image_set(
                 RF,
-                fsdd_train_images,
-                fsdd_train_labels,
-                fsdd_test_images,
-                fsdd_test_labels,
+                fsdk18_train_images,
+                fsdk18_train_labels,
+                fsdk18_test_images,
+                fsdk18_test_labels,
                 samples,
                 classes,
             )
@@ -315,7 +315,7 @@ if __name__ == "__main__":
 
     # data is normalized upon loading
     # load dataset
-    x_spec, y_number = load_spoken_digit(
+    x_spec, y_number = load_fsdk18(
         path_recordings, labels_chosen, get_labels, feature_type
     )
     nums = list(range(18))
@@ -347,11 +347,11 @@ if __name__ == "__main__":
     )
 
     # 3000 samples, 80% train is 2400 samples, 20% test
-    fsdd_train_images = trainx.reshape(-1, 32 * 32)
-    fsdd_train_labels = trainy.copy()
+    fsdk18_train_images = trainx.reshape(-1, 32 * 32)
+    fsdk18_train_labels = trainy.copy()
     # reshape in 2d array
-    fsdd_test_images = testx.reshape(-1, 32 * 32)
-    fsdd_test_labels = testy.copy()
+    fsdk18_test_images = testx.reshape(-1, 32 * 32)
+    fsdk18_test_labels = testy.copy()
 
     run_naive_rf()
     run_cnn32()

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -404,7 +404,7 @@ def run_dn_image_es(
     test_labels,
     epochs=30,
     lr=0.001,
-    batch=64,
+    batch=60,
 ):
     """
     Peforms multiclass predictions for a deep network classifier with set number

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -9,17 +9,84 @@ import os
 import cv2
 import librosa
 import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
 from sklearn.metrics import cohen_kappa_score
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from torch.utils.data import Dataset
+import torchaudio
 import torchaudio.transforms as trans
 
+class FSDKaggle18Dataset(Dataset):
+  """
+  This class is based on torch.utils.data.Dataset for loading the entire 
+  FSDKaggle18 Dataset using native torch and torchaudio primitives.
 
-def load_spoken_digit(path_recordings, feature_type="spectrogram"):
-    file = os.listdir(path_recordings)
+  ----------------------------------------------------
+  Input parameters:
+    annotations_file: str
+    Path to the file containing the ground truths
+
+    audio_dir: str
+    Path to the folder containing the audio files
+
+  Returns:
+  instance of torch.utils.data.Dataset() returning the audio file together with it's corresponding label.
+
+  """    
+  def __init__(self, annotations_file, audio_dir):
+    #loop through the csv entries and only add entries from folders in the folder list
+    self.annotations = pd.read_csv(annotations_file)
+    self.audio_dir = audio_dir
+    data_final = []
+    for filepaths in os.listdir(self.audio_dir):
+      data_final.append(os.path.join(self.audio_dir,filepaths))
+    self.data_final = data_final
+
+  def __getitem__(self, index):
+    audio_sample_path = self._get_sample_path(index)
+    label = self._get_label_(index)
+    signal, sr = torchaudio.load(audio_sample_path)
+    return signal, sr, label
+  
+  def _get_sample_path(self, index):
+    return os.path.join(self.audio_dir, self.annotations.iloc[index,0])
+
+  def _get_label_(self,index1):
+    labels_to_index = {'Acoustic_guitar': 0, 'Applause': 1, 'Bark': 2, 'Bass_drum': 3, 'Burping_or_eructation': 4, 'Bus': 5, 'Cello': 6, 'Chime': 7, 'Clarinet': 8, 'Computer_keyboard': 9, 'Cough': 10, 'Cowbell': 11, 'Double_bass': 12, 'Drawer_open_or_close': 13, 'Electric_piano': 14, 'Fart': 15, 'Finger_snapping': 16, 'Fireworks': 17, 'Flute': 18, 'Glockenspiel': 19, 'Gong': 20, 'Gunshot_or_gunfire': 21, 'Harmonica': 22, 'Hi-hat': 23, 'Keys_jangling': 24, 'Knock': 25, 'Laughter': 26, 'Meow': 27, 'Microwave_oven': 28, 'Oboe': 29, 'Saxophone': 30, 'Scissors': 31, 'Shatter': 32, 'Snare_drum': 33, 'Squeak': 34, 'Tambourine': 35, 'Tearing': 36, 'Telephone': 37, 'Trumpet': 38, 'Violin_or_fiddle': 39, 'Writing': 40}
+    get_labels = self.annotations['label'].replace(labels_to_index).to_list()
+    y_value = get_labels[index1]
+    return y_value
+
+  def __len__(self):
+    return len(os.listdir(self.audio_dir))
+
+  def plot_waveform(waveform, sample_rate, title="Waveform", xlim=None, ylim=None):
+    waveform = waveform.numpy()
+
+    num_channels, num_frames = waveform.shape
+    time_axis = torch.arange(0, num_frames) / sample_rate
+
+    figure, axes = plt.subplots(num_channels, 1)
+    if num_channels == 1:
+      axes = [axes]
+    for c in range(num_channels):
+      axes[c].plot(time_axis, waveform[c], linewidth=1)
+      axes[c].grid(True)
+      if num_channels > 1:
+        axes[c].set_ylabel(f'Channel {c+1}')
+      if xlim:
+        axes[c].set_xlim(xlim)
+      if ylim:
+        axes[c].set_ylim(ylim)
+    figure.suptitle(title)
+    plt.show(block=False)
+
+def load_spoken_digit(path_recordings, labels_file, label_arr, feature_type="spectrogram"):
 
     audio_data = []  # audio data
     x_spec = []  # STFT spectrogram
@@ -32,24 +99,23 @@ def load_spoken_digit(path_recordings, feature_type="spectrogram"):
         a = trans.MelSpectrogram(n_fft=128, normalized=True)
     elif feature_type == "mfcc":
         a = trans.MFCC(n_mfcc=128)
-    for i in file:
-        x, sr = librosa.load(path_recordings + i, sr=8000)
+    for i in path_recordings:
+        x, sr = librosa.load(i, sr = 44100)
+        i = i[-12:]
         x_stft_db = a(torch.tensor(x)).numpy()
         # Convert an amplitude spectrogram to dB-scaled spectrogram
         x_stft_db_mini = cv2.resize(x_stft_db, (32, 32))  # Resize into 32 by 32
-        y_n = i[0]  # number
-        y_s = i[2]  # first letter of speaker's name
+        get_label_location = int(labels_file.fname.index[labels_file['fname'] == i].to_numpy())
 
+        y_s = label_arr[get_label_location]  # label number
         audio_data.append(x)
         x_spec.append(x_stft_db)
         x_spec_mini.append(x_stft_db_mini)
-        y_number.append(y_n)
-        y_speaker.append(y_s)
+        y_number.append(y_s)
 
     x_spec_mini = np.array(x_spec_mini)
     y_number = np.array(y_number).astype(int)
-    y_speaker = np.array(y_speaker)
-
+    
     return x_spec_mini, y_number
 
 

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -131,9 +131,7 @@ class FSDKaggle18Dataset(Dataset):
         plt.show(block=False)
 
 
-def load_fsdk18(
-    path_recordings, labels_file, label_arr, feature_type="spectrogram"
-):
+def load_fsdk18(path_recordings, labels_file, label_arr, feature_type="spectrogram"):
 
     audio_data = []  # audio data
     x_audio = []  # STFT spectrogram

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -21,72 +21,119 @@ from torch.utils.data import Dataset
 import torchaudio
 import torchaudio.transforms as trans
 
+
 class FSDKaggle18Dataset(Dataset):
-  """
-  This class is based on torch.utils.data.Dataset for loading the entire 
-  FSDKaggle18 Dataset using native torch and torchaudio primitives.
+    """
+    This class is based on torch.utils.data.Dataset for loading the entire
+    FSDKaggle18 Dataset using native torch and torchaudio primitives.
 
-  ----------------------------------------------------
-  Input parameters:
-    annotations_file: str
-    Path to the file containing the ground truths
+    ----------------------------------------------------
+    Input parameters:
+      annotations_file: str
+      Path to the file containing the ground truths
 
-    audio_dir: str
-    Path to the folder containing the audio files
+      audio_dir: str
+      Path to the folder containing the audio files
 
-  Returns:
-  instance of torch.utils.data.Dataset() returning the audio file together with it's corresponding label.
+    Returns:
+    instance of torch.utils.data.Dataset() returning the audio file together with it's corresponding label.
 
-  """    
-  def __init__(self, annotations_file, audio_dir):
-    #loop through the csv entries and only add entries from folders in the folder list
-    self.annotations = pd.read_csv(annotations_file)
-    self.audio_dir = audio_dir
-    data_final = []
-    for filepaths in os.listdir(self.audio_dir):
-      data_final.append(os.path.join(self.audio_dir,filepaths))
-    self.data_final = data_final
+    """
 
-  def __getitem__(self, index):
-    audio_sample_path = self._get_sample_path(index)
-    label = self._get_label_(index)
-    signal, sr = torchaudio.load(audio_sample_path)
-    return signal, sr, label
-  
-  def _get_sample_path(self, index):
-    return os.path.join(self.audio_dir, self.annotations.iloc[index,0])
+    def __init__(self, annotations_file, audio_dir):
+        # loop through the csv entries and only add entries from folders in the folder list
+        self.annotations = pd.read_csv(annotations_file)
+        self.audio_dir = audio_dir
+        data_final = []
+        for filepaths in os.listdir(self.audio_dir):
+            data_final.append(os.path.join(self.audio_dir, filepaths))
+        self.data_final = data_final
 
-  def _get_label_(self,index1):
-    labels_to_index = {'Acoustic_guitar': 0, 'Applause': 1, 'Bark': 2, 'Bass_drum': 3, 'Burping_or_eructation': 4, 'Bus': 5, 'Cello': 6, 'Chime': 7, 'Clarinet': 8, 'Computer_keyboard': 9, 'Cough': 10, 'Cowbell': 11, 'Double_bass': 12, 'Drawer_open_or_close': 13, 'Electric_piano': 14, 'Fart': 15, 'Finger_snapping': 16, 'Fireworks': 17, 'Flute': 18, 'Glockenspiel': 19, 'Gong': 20, 'Gunshot_or_gunfire': 21, 'Harmonica': 22, 'Hi-hat': 23, 'Keys_jangling': 24, 'Knock': 25, 'Laughter': 26, 'Meow': 27, 'Microwave_oven': 28, 'Oboe': 29, 'Saxophone': 30, 'Scissors': 31, 'Shatter': 32, 'Snare_drum': 33, 'Squeak': 34, 'Tambourine': 35, 'Tearing': 36, 'Telephone': 37, 'Trumpet': 38, 'Violin_or_fiddle': 39, 'Writing': 40}
-    get_labels = self.annotations['label'].replace(labels_to_index).to_list()
-    y_value = get_labels[index1]
-    return y_value
+    def __getitem__(self, index):
+        audio_sample_path = self._get_sample_path(index)
+        label = self._get_label_(index)
+        signal, sr = torchaudio.load(audio_sample_path)
+        return signal, sr, label
 
-  def __len__(self):
-    return len(os.listdir(self.audio_dir))
+    def _get_sample_path(self, index):
+        return os.path.join(self.audio_dir, self.annotations.iloc[index, 0])
 
-  def plot_waveform(waveform, sample_rate, title="Waveform", xlim=None, ylim=None):
-    waveform = waveform.numpy()
+    def _get_label_(self, index1):
+        labels_to_index = {
+            "Acoustic_guitar": 0,
+            "Applause": 1,
+            "Bark": 2,
+            "Bass_drum": 3,
+            "Burping_or_eructation": 4,
+            "Bus": 5,
+            "Cello": 6,
+            "Chime": 7,
+            "Clarinet": 8,
+            "Computer_keyboard": 9,
+            "Cough": 10,
+            "Cowbell": 11,
+            "Double_bass": 12,
+            "Drawer_open_or_close": 13,
+            "Electric_piano": 14,
+            "Fart": 15,
+            "Finger_snapping": 16,
+            "Fireworks": 17,
+            "Flute": 18,
+            "Glockenspiel": 19,
+            "Gong": 20,
+            "Gunshot_or_gunfire": 21,
+            "Harmonica": 22,
+            "Hi-hat": 23,
+            "Keys_jangling": 24,
+            "Knock": 25,
+            "Laughter": 26,
+            "Meow": 27,
+            "Microwave_oven": 28,
+            "Oboe": 29,
+            "Saxophone": 30,
+            "Scissors": 31,
+            "Shatter": 32,
+            "Snare_drum": 33,
+            "Squeak": 34,
+            "Tambourine": 35,
+            "Tearing": 36,
+            "Telephone": 37,
+            "Trumpet": 38,
+            "Violin_or_fiddle": 39,
+            "Writing": 40,
+        }
+        get_labels = self.annotations["label"].replace(labels_to_index).to_list()
+        y_value = get_labels[index1]
+        return y_value
 
-    num_channels, num_frames = waveform.shape
-    time_axis = torch.arange(0, num_frames) / sample_rate
+    def __len__(self):
+        return len(os.listdir(self.audio_dir))
 
-    figure, axes = plt.subplots(num_channels, 1)
-    if num_channels == 1:
-      axes = [axes]
-    for c in range(num_channels):
-      axes[c].plot(time_axis, waveform[c], linewidth=1)
-      axes[c].grid(True)
-      if num_channels > 1:
-        axes[c].set_ylabel(f'Channel {c+1}')
-      if xlim:
-        axes[c].set_xlim(xlim)
-      if ylim:
-        axes[c].set_ylim(ylim)
-    figure.suptitle(title)
-    plt.show(block=False)
+    def plot_waveform(waveform, sample_rate, title="Waveform", xlim=None, ylim=None):
+        waveform = waveform.numpy()
 
-def load_spoken_digit(path_recordings, labels_file, label_arr, feature_type="spectrogram"):
+        num_channels, num_frames = waveform.shape
+        time_axis = torch.arange(0, num_frames) / sample_rate
+
+        figure, axes = plt.subplots(num_channels, 1)
+        if num_channels == 1:
+            axes = [axes]
+        for c in range(num_channels):
+            axes[c].plot(time_axis, waveform[c], linewidth=1)
+            axes[c].grid(True)
+            if num_channels > 1:
+                axes[c].set_ylabel(f"Channel {c+1}")
+            if xlim:
+                axes[c].set_xlim(xlim)
+            if ylim:
+                axes[c].set_ylim(ylim)
+        figure.suptitle(title)
+        plt.show(block=False)
+
+
+def load_spoken_digit(
+    path_recordings, labels_file, label_arr, feature_type="spectrogram"
+):
 
     audio_data = []  # audio data
     x_spec = []  # STFT spectrogram
@@ -100,12 +147,14 @@ def load_spoken_digit(path_recordings, labels_file, label_arr, feature_type="spe
     elif feature_type == "mfcc":
         a = trans.MFCC(n_mfcc=128)
     for i in path_recordings:
-        x, sr = librosa.load(i, sr = 44100)
+        x, sr = librosa.load(i, sr=44100)
         i = i[-12:]
         x_stft_db = a(torch.tensor(x)).numpy()
         # Convert an amplitude spectrogram to dB-scaled spectrogram
         x_stft_db_mini = cv2.resize(x_stft_db, (32, 32))  # Resize into 32 by 32
-        get_label_location = int(labels_file.fname.index[labels_file['fname'] == i].to_numpy())
+        get_label_location = int(
+            labels_file.fname.index[labels_file["fname"] == i].to_numpy()
+        )
 
         y_s = label_arr[get_label_location]  # label number
         audio_data.append(x)
@@ -115,7 +164,7 @@ def load_spoken_digit(path_recordings, labels_file, label_arr, feature_type="spe
 
     x_spec_mini = np.array(x_spec_mini)
     y_number = np.array(y_number).astype(int)
-    
+
     return x_spec_mini, y_number
 
 

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -487,8 +487,8 @@ def prepare_data(
     for cls in classes:
         test_idx = np.argwhere(test_labels == cls).flatten()
         # out of all, 0.3 validation, 0.7 test
-        test_idxs.append(test_idx[int(len(test_idx) * 0.3) :])
-        validation_idxs.append(test_idx[: int(len(test_idx) * 0.3)])
+        test_idxs.append(test_idx[int(len(test_idx) * 0.5) :])
+        validation_idxs.append(test_idx[: int(len(test_idx) * 0.5)])
 
     test_idxs = np.concatenate(test_idxs)
     validation_idxs = np.concatenate(validation_idxs)

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -131,15 +131,14 @@ class FSDKaggle18Dataset(Dataset):
         plt.show(block=False)
 
 
-def load_spoken_digit(
+def load_fsdk18(
     path_recordings, labels_file, label_arr, feature_type="spectrogram"
 ):
 
     audio_data = []  # audio data
-    x_spec = []  # STFT spectrogram
-    x_spec_mini = []  # resized image, 32*32
-    y_number = []  # label of number
-    y_speaker = []  # label of speaker
+    x_audio = []  # STFT spectrogram
+    x_audio_mini = []  # resized image, 32*32
+    y_number = []  # label of number  # label of speaker
     if feature_type == "spectrogram":
         a = trans.Spectrogram(n_fft=128, normalized=True)
     elif feature_type == "melspectrogram":
@@ -156,16 +155,16 @@ def load_spoken_digit(
             labels_file.fname.index[labels_file["fname"] == i].to_numpy()
         )
 
-        y_s = label_arr[get_label_location]  # label number
+        y_n = label_arr[get_label_location]  # label number
         audio_data.append(x)
-        x_spec.append(x_stft_db)
-        x_spec_mini.append(x_stft_db_mini)
-        y_number.append(y_s)
+        x_audio.append(x_stft_db)
+        x_audio_mini.append(x_stft_db_mini)
+        y_number.append(y_n)
 
-    x_spec_mini = np.array(x_spec_mini)
+    x_audio_mini = np.array(x_audio_mini)
     y_number = np.array(y_number).astype(int)
 
-    return x_spec_mini, y_number
+    return x_audio_mini, y_number
 
 
 class SimpleCNN32Filter(nn.Module):

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -486,7 +486,7 @@ def prepare_data(
     validation_idxs = []
     for cls in classes:
         test_idx = np.argwhere(test_labels == cls).flatten()
-        # out of all, 0.3 validation, 0.7 test
+        # out of all, 0.5 validation, 0.5 test
         test_idxs.append(test_idx[int(len(test_idx) * 0.5) :])
         validation_idxs.append(test_idx[: int(len(test_idx) * 0.5)])
 

--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -165,6 +165,41 @@ def load_fsdk18(path_recordings, labels_file, label_arr, feature_type="spectrogr
     return x_audio_mini, y_number
 
 
+def load_spoken_digit(path_recordings, feature_type="spectrogram"):
+    file = os.listdir(path_recordings)
+
+    audio_data = []  # audio data
+    x_spec = []  # STFT spectrogram
+    x_spec_mini = []  # resized image, 32*32
+    y_number = []  # label of number
+    y_speaker = []  # label of speaker
+    if feature_type == "spectrogram":
+        a = trans.Spectrogram(n_fft=128, normalized=True)
+    elif feature_type == "melspectrogram":
+        a = trans.MelSpectrogram(n_fft=128, normalized=True)
+    elif feature_type == "mfcc":
+        a = trans.MFCC(n_mfcc=128)
+    for i in file:
+        x, sr = librosa.load(path_recordings + i, sr=8000)
+        x_stft_db = a(torch.tensor(x)).numpy()
+        # Convert an amplitude spectrogram to dB-scaled spectrogram
+        x_stft_db_mini = cv2.resize(x_stft_db, (32, 32))  # Resize into 32 by 32
+        y_n = i[0]  # number
+        y_s = i[2]  # first letter of speaker's name
+
+        audio_data.append(x)
+        x_spec.append(x_stft_db)
+        x_spec_mini.append(x_stft_db_mini)
+        y_number.append(y_n)
+        y_speaker.append(y_s)
+
+    x_spec_mini = np.array(x_spec_mini)
+    y_number = np.array(y_number).astype(int)
+    y_speaker = np.array(y_speaker)
+
+    return x_spec_mini, y_number
+
+
 class SimpleCNN32Filter(nn.Module):
     """
     Defines a simple CNN arhcitecture


### PR DESCRIPTION
Added code that uses the [ FSDKaggle2018 Dataset](https://zenodo.org/record/2552860#.YbZRc71KhPa) instead of the FSDD Dataset for audition tasks.

The code addresses the following issues:

- [Issue #42](https://github.com/neurodata/df-dn-paper/issues/42) - Updating the audition codebase for using the new dataset. 
Changes have been made to benchmarks/audition/fsdd.py and benchmarks/audition/toolbox.py file
- [Issue #43](https://github.com/neurodata/df-dn-paper/issues/43) - Creation of a Pytorch native Dataset and DataLoader primitive for the new dataset. 
Changes have been made to the benchmarks/audition/toolbox.py file
